### PR TITLE
only trim start

### DIFF
--- a/crates/rari-doc/src/html/rewriter.rs
+++ b/crates/rari-doc/src/html/rewriter.rs
@@ -48,6 +48,7 @@ pub fn post_process_html<T: PageLike>(
     ))?;
     let base_url = options.base_url(Some(&base));
     let data_issues = settings().data_issues;
+    let mut in_pre = false;
 
     let mut element_content_handlers = vec![
         element!("*[id]", |el| {
@@ -109,8 +110,12 @@ pub fn post_process_html<T: PageLike>(
         text!("pre[class*=brush]", |text| {
             // trim the first _empty_ line,
             // fixes issue: https://github.com/mdn/yari/issues/12364
-            if let Some('\n') = text.as_str().chars().next() {
-                text.as_mut_str().drain(..1);
+            if !in_pre && text.as_str().starts_with('\n') {
+                text.as_mut_str().remove(0);
+            }
+            in_pre = true;
+            if text.last_in_text_node() {
+                in_pre = false;
             }
             Ok(())
         }),


### PR DESCRIPTION
### Description

The function may be executed multiple times since text is chunked. So without keeping track this removed newlines in other places.


I usually do two full builds (to `/tmp/rari-1` and /tmp/rari-2`) and and then compare them via:

`cargo run -r -p diff-test --  diff --fast  --value --html --sidebars -o /tmp/diff.html /tmp/{rari-1,rari-2}/en-us/docs`

We'll stabilize and this soon an document it.